### PR TITLE
support for multiple LAN IP addresses

### DIFF
--- a/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua
+++ b/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua
@@ -31,6 +31,15 @@ end
 
 local lanIPAddr = uci:get("network", "lan", "ipaddr")
 local lanNetmask = uci:get("network", "lan", "netmask")
+-- if multiple ip addresses on lan interface, will be return as table of CIDR notations i.e. {"10.0.0.1/24","10.0.0.2/24"}
+if (type(lanIPAddr) == "table") then                                                                                   
+        first = true                                                                                             
+        for i,line in ipairs(lanIPAddr) do                                                                  
+                lanIPAddr = lanIPAddr[i]                                                                    
+                break                                           
+        end                                                     
+        lanIPAddr = string.match(lanIPAddr,"[0-9.]+")                                                            
+end          
 if lanIPAddr and lanNetmask then
 	laPlaceholder = ip.new(lanIPAddr .. "/" .. lanNetmask )
 end


### PR DESCRIPTION
Support for multiple LAN IP Addresses; UCI provides them as a table in CIDR notation instead of a string if multiple addresses are associated with the LAN interface.  This change uses the first entry as the placeholder.