### PR TITLE
A bunch of improvements.

### DIFF
--- a/simple-adblock/files/simple-adblock.init
+++ b/simple-adblock/files/simple-adblock.init
@@ -9,6 +9,7 @@ readonly packageName='simple-adblock'
 readonly serviceName="$packageName $PKG_VERSION"
 readonly PID="/var/run/${packageName}.pid"
 readonly dnsmasqFile="/var/dnsmasq.d/${packageName}"
+readonly compressedBackup="/etc/${packageName}.gz"
 export EXTRA_COMMANDS="check download killcache"
 export EXTRA_HELP="	check	Checks if specified domain is found in current blacklist
 	download	Force-redownloads all the lists, even if the last download was successful and no config changes were made"
@@ -68,7 +69,7 @@ export blacklist_domains
 export whitelist_domains_urls
 export blacklist_domains_urls
 export blacklist_hosts_urls
-export wan_if wan_gw wanphysdev dl_command serviceStatus
+export wan_if wan_gw wanphysdev dl_command serviceStatus oflag
 
 load_package_config() {
 	config_load "$packageName"
@@ -90,7 +91,20 @@ load_package_config() {
 		verbosity=1
 	fi
 	. /lib/functions/network.sh
-	dl_command="wget --no-check-certificate --timeout $dlTimeout -q"
+	# Prefer curl because it supports the file: scheme. This allows you
+	# to have a local list of domains, eg. file:///etc/block-these.txt or
+	# file:///etc/allow-these.txt and have them merged into the downloaded
+	# lists. When processing a large locally adminstered list, this can be
+	# much faster than using the blacklisted domains configuration. This is
+	# not going to be a hard dependency though, because wget is generally
+	# sufficient.
+	if [ -x /usr/bin/curl ] ; then
+		dl_command="curl --insecure --connect-timeout $dlTimeout --silent"
+		oflag="-o"
+	else
+		dl_command="wget --no-check-certificate --timeout $dlTimeout -q"
+		oflag="-O"
+	fi
 	led="${led:+/sys/class/leds/$led}"
 }
 
@@ -150,6 +164,13 @@ dnsmasq_restart() { /etc/init.d/dnsmasq restart >/dev/null 2>&1; }
 reload_dnsmasq() {
 	case $1 in
 		on_start)
+			if [ -f $compressedBackup ] ; then
+				output 2 "using cached block list"
+				X=$(mktemp ${dnsmasqFile}.XXXXXXXXXXX)
+				gzip -dc < ${compressedBackup} > $X
+				mv $X ${dnsmasqFile}
+				output_ok
+			fi
 			if [ -s $dnsmasqFile ]; then
 				output 3 'Restarting dnsmasq '
 				if dnsmasq_restart; then
@@ -249,7 +270,7 @@ process_url() {
 	while [ -z "$R_TMP" ] || [ -e "$R_TMP" ]; do
 		R_TMP="/var/${packageName}_tmp_$(head -c40 /dev/urandom 2>/dev/null | tr -dc 'A-Za-z0-9' 2>/dev/null)"
 	done
-	if ! $dl_command "$1" -O "$R_TMP" 2>/dev/null || [ ! -s "$R_TMP" ]; then
+	if ! $dl_command "$1" $oflag "$R_TMP" 2>/dev/null || [ ! -s "$R_TMP" ]; then
 		output 2 "[DL] $type $label $__FAIL__\\n"
 		output 1 "$_FAIL_"
 		ubus_status add '-'
@@ -273,6 +294,7 @@ download_lists() {
 		output 3 'Low free memory, restarting dnsmasq...'
 		if reload_dnsmasq 'quiet'; then output_okn; else output_failn; fi
 	fi
+	rm -f $compressedBackup
 	touch $A_TMP; touch $B_TMP;
 	output 1 'Downloading lists '
 	if [ -n "$blacklist_hosts_urls" ]; then
@@ -367,19 +389,54 @@ $(cat $A_TMP)"
 				serviceStatus="${serviceStatus:-'Whitelist processing error'}"
 			fi
 			output 2 'Formatting merged file '
-			if sed "$f_filter" $B_TMP > $A_TMP; then
+			# this egrep filters out non-ascii characters which make dnsmasq
+			# sad. Some lists have wierd unicode characters for homoglyph
+			# attacks but dnsmasq throws an error when trying to parse those
+			# lines.
+			if sed "$f_filter" $B_TMP | egrep -v '[^a-zA-Z0-9=/.-]' > $A_TMP; then
 				output_ok
 			else
 				output_fail
 				serviceStatus="${serviceStatus:-'Data file formatting error'}"
 			fi
 			output 2 'Creating dnsmasq config '
+
+			# If you have a list of blacklisted domains (maybe even TLDs) this
+			# bit will filter all of them out of the block files. It does this
+			# by building converting the "blacklist_domain" list to a regex to
+			# excludes lines matching the blacklisted domains. These domains
+			# are then used to begin the dnsmasq config, followed by blocked
+			# domains that passed the local filter.
+			#
+			# So you can efficiently block all of .com/.org/.net if you want...
+			RGX=$(uci -X show simple-adblock.config.blacklist_domain | cut -d = -f 2 | sed -e 's/ /\n/g'| grep -v '[.]' | tr -d "'" | xargs | tr " "  "|" )
+			echo $RGX | tr '|' '\n' | sed -e "s,^,local=/," -e 's,$,/,' > $B_TMP
+			egrep -v "[.]($RGX)/" $A_TMP >> $B_TMP
+			mv $B_TMP $A_TMP
+
 			if mv $A_TMP $dnsmasqFile; then
 				output_ok
 			else
 				output_fail
 				serviceStatus="${serviceStatus:-'Error moving data file'}"
 			fi
+
+			output 2 'Creating expressed backup '
+			# attempt to create a compressed backup of the dnsmasq
+			# configuration. It may take a long time to download the
+			# lists over a slow network, it may place a large burden
+			# on a low power device... so let's save some electrons
+			# and cache it. It can easily be only 20-25% of the size
+			# of the dnsmasq file
+			X=$(mktemp /etc/delete-this-file.XXXXXXXXXXX)
+			if gzip < $dnsmasqFile > $X ; then
+				mv $X $compressedBackup
+				output_ok
+			else
+				output_fail
+				rm -f $X
+			fi
+
 			output 2 'Removing temporary files '
 			rm -f /var/simple-adblock_tmp_* >/dev/null 2>&1;
 			for i in $A_TMP $B_TMP $CACHE_TMP; do if [ -s $i ]; then rm -f $i || j=1; fi; done


### PR DESCRIPTION
- prefer curl if it's available because it supports file:
- additional optimization for filtering out matching domains or TLDs
- filter out unicode domains that would cause dnsmasq errors
- implement a compressed backup file to allow for faster startup

These turn out to be quite valuable on low resource devices like the gl.inet gl-usb150 which only has 64M RAM and 16MB flash (about 7MB free)