### PR TITLE
allow simple-adblock to start up when WAN is down but cache is present

### DIFF
--- a/simple-adblock/files/simple-adblock.init
+++ b/simple-adblock/files/simple-adblock.init
@@ -416,18 +416,18 @@ $(cat $A_TMP)"
 		fi
 
 		output 2 'Creating dnsmasq config '
-#			# If you have a list of blacklisted domains (maybe even TLDs) this
-#			# bit will filter all of them out of the block files. It does this
-#			# by building converting the "blacklist_domain" list to a regex to
-#			# excludes lines matching the blacklisted domains. These domains
-#			# are then used to begin the dnsmasq config, followed by blocked
-#			# domains that passed the local filter.
-#			#
-#			# So you can efficiently block all of .com/.org/.net if you want...
-#			RGX=$(uci -X show simple-adblock.config.blacklist_domain | cut -d = -f 2 | sed -e 's/ /\n/g'| grep -v '[.]' | tr -d "'" | xargs | tr " "  "|" )
-#			echo $RGX | tr '|' '\n' | sed -e "s,^,local=/," -e 's,$,/,' > $B_TMP
-#			egrep -v "[.]($RGX)/" $A_TMP >> $B_TMP
-#			mv $B_TMP $A_TMP
+		# If you have a list of blacklisted domains (maybe even TLDs) this
+		# bit will filter all of them out of the block files. It does this
+		# by building converting the "blacklist_domain" list to a regex to
+		# excludes lines matching the blacklisted domains. These domains
+		# are then used to begin the dnsmasq config, followed by blocked
+		# domains that passed the local filter.
+		#
+		# So you can efficiently block all of .com/.org/.net if you want...
+		RGX=$(uci -X show simple-adblock.config.blacklist_domain | cut -d = -f 2 | sed -e 's/ /\n/g'| grep -v '[.]' | tr -d "'" | xargs | tr " "  "|" )
+		echo $RGX | tr '|' '\n' | sed -e "s,^,local=/," -e 's,$,/,' > $B_TMP
+		egrep -v "[.]($RGX)/" $A_TMP >> $B_TMP
+		mv $B_TMP $A_TMP
 		if mv $A_TMP $dnsmasqFile; then
 			output_ok
 		else

--- a/simple-adblock/files/simple-adblock.init
+++ b/simple-adblock/files/simple-adblock.init
@@ -128,6 +128,7 @@ is_enabled() {
 	[ ! -d ${stateFile%/*} ] && mkdir -p ${stateFile%/*}
 	network_flush_cache; network_find_wan wan_if; network_get_gateway wan_gw "$wan_if";
 	[ -n "$wan_gw" ] && return 0
+	test -f "$compressedBackup" && return 0
 	output "$_ERROR_: $serviceName failed to discover WAN gateway.\\n"; return 1;
 }
 
@@ -500,6 +501,18 @@ start_service() {
 			output "Starting $serviceName...\\n"
 			output 3 'Found existing data file, reusing it '
 			if mv $CACHE_TMP $dnsmasqFile; then output_okn; else output_failn; fi
+			reload_dnsmasq 'on_start' || serviceStatus="${serviceStatus:-'DNSMASQ restart error'}"
+		elif [ -s "$compressedBackup" ] && [ "$action" != "download" ]; then
+			output "Starting $serviceName...\\n"
+			output 3 'Found compressed backup file, reusing it '
+			R_TMP="$(mktemp -u -q -t ${dnsmasqFile}_tmp.XXXXXXXX)"
+			if gzip -dc < "${compressedBackup}" > "$R_TMP"; then
+				mv "$R_TMP" "${dnsmasqFile}"
+				output_okn
+			else
+				rm -f "$R_TMP"
+				output failn
+			fi
 			reload_dnsmasq 'on_start' || serviceStatus="${serviceStatus:-'DNSMASQ restart error'}"
 		elif [ "$action" = "download" ] || [ "$status" != "${status//rror}" ]; then
 			output "Force-reloading $serviceName...\\n"

--- a/simple-adblock/files/simple-adblock.init
+++ b/simple-adblock/files/simple-adblock.init
@@ -297,7 +297,7 @@ download_lists() {
 	local i hf w_filter j=0 R_TMP
 
 	ubus_status set 'Reloading '
-	for i in $A_TMP $B_TMP $CACHE_TMP $dnsmasqFile $compressedBackup; do [ -f $i ] && rm -f $i; done
+	for i in $A_TMP $B_TMP $CACHE_TMP $dnsmasqFile; do [ -f $i ] && rm -f $i; done
 	if [ "$(awk '/^MemFree/ {print int($2/1000)}' "/proc/meminfo")" -lt 32 ]; then
 		output 3 'Low free memory, restarting dnsmasq...'
 		if reload_dnsmasq 'quiet'; then output_okn; else output_failn; fi
@@ -445,6 +445,8 @@ $(cat $A_TMP)"
 				output_fail
 				rm -f "$R_TMP"
 			fi
+		else
+			rm -f "$compressedBackup"
 		fi
 
 		output 2 'Removing temporary files '


### PR DESCRIPTION
It looks like the point of the WAN check is to see if it's possible to download the various lists, but this is not necessary if you have a local cache file.

`simple-adblock dl` still forces a download even when the cache is present, as expected.