### PR TITLE
Disallow uhttpd directory listing

### DIFF
--- a/fakeinternet/files/fakeinternet.init
+++ b/fakeinternet/files/fakeinternet.init
@@ -139,7 +139,7 @@ start_service() {
 	is_enabled || return 1
 	dns_forward 'start' || return 1
 	procd_open_instance 'main'
-	procd_set_param command /usr/sbin/uhttpd -f -h /www_fakeinternet -r fakeinternet -x /cgi-bin -u /ubus -t 60 -T 30 -k 20 -E /error.cgi -n 3 -N 100 -R -p "0.0.0.0:${wwwPort}" -p "[::]:${wwwPort}" -i .cgi=/bin/ash
+	procd_set_param command /usr/sbin/uhttpd -f -h /www_fakeinternet -r fakeinternet -x /cgi-bin -u /ubus -t 60 -T 30 -k 20 -E /error.cgi -n 3 -N 100 -R -p "0.0.0.0:${wwwPort}" -p "[::]:${wwwPort}" -i .cgi=/bin/ash -D 1
 	procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 	procd_set_param stdout 1
 	procd_set_param stderr 1


### PR DESCRIPTION
This minor patch disables uhttpd directory listing as reported in the forumn post here
https://forum.openwrt.org/t/fakeinternet-service-package/924/29?u=arky