### PR TITLE
Fix dnsmasq options detection

### DIFF
--- a/vpn-policy-routing/files/vpn-policy-routing.init
+++ b/vpn-policy-routing/files/vpn-policy-routing.init
@@ -129,7 +129,7 @@ dnsmasq_kill() { killall -q -HUP dnsmasq; }
 dnsmasq_restart() { output 1 'Restarting DNSMASQ '; if /etc/init.d/dnsmasq restart >/dev/null 2>&1; then output_okn; else output_failn; fi; }
 is_default_dev() { [ "$1" = "$(ip -4 r | grep -m1 'dev' | grep -Eso 'dev [^ ]*' | awk '{print $2}')" ]; }
 is_supported_iface_dev() {
-	for n in $ifSupported; do 
+	for n in $ifSupported; do
 		if [ "$1" = "$(uci -q get "network.${n}.ifname" || echo "$n")" ] || [ "$1" = "$(uci -q get "network.${n}.proto")-${n}" ] ; then return 0; fi
 	done
 	return 1
@@ -196,7 +196,7 @@ is_enabled() {
 			fi
 			;;
 		dnsmasq.ipset)
-			if dnsmasq -v 2>/dev/null | grep -q 'no-ipset' || ! dnsmasq -v 2>/dev/null | grep -q -w 'ipset'; then
+			if dnsmasq -v 2>/dev/null | grep -q 'no-ipset' || ! dnsmasq -v 2>/dev/null | grep -q ' ipset'; then
 				output "$_ERROR_: DNSMASQ ipset support is enabled in $packageName, but DNSMASQ is either not installed or installed DNSMASQ does not support ipsets!\\n"
 				unset remoteIpset
 			fi
@@ -207,7 +207,7 @@ is_enabled() {
 			;;
 		*) unset remoteIpset;;
 	esac
-	
+
 	if [ "$localIpset" -ne 0 ]; then
 		if ! ipset help hash:net >/dev/null 2>&1; then
 			output "$_ERROR_: Local ipset support is enabled in $packageName, but ipset is either not installed or installed ipset does not support 'hash:net' type!\\n"
@@ -236,8 +236,8 @@ is_wan_up() {
 	config_load 'network'
 	config_foreach list_supported_iface 'interface'
 	if [ -n "$wanGW" ]; then
-		return 0	
-	else	
+		return 0
+	else
 		output "$_ERROR_: $serviceName failed to discover WAN gateway!\\n"
 		return 1
 	fi
@@ -256,7 +256,7 @@ ipt_cleanup() {
 # shellcheck disable=SC2086
 ipt() {
 	local d failFlagIpv4=1 failFlagIpv6=1
-	for d in "${*//-A/-D}" "${*//-I/-D}" "${*//-N/-F}" "${*//-N/-X}"; do 
+	for d in "${*//-A/-D}" "${*//-I/-D}" "${*//-N/-F}" "${*//-N/-X}"; do
 		[ "$d" != "$*" ] && { iptables $d >/dev/null 2>&1; ip6tables $d >/dev/null 2>&1; }
 	done
 
@@ -348,7 +348,7 @@ insert_policy() {
 	fi
 
 	if [ -z "$proto" ]; then
-		if [ -n "$lport" ] || [ -n "$rport" ]; then 
+		if [ -n "$lport" ] || [ -n "$rport" ]; then
 			proto='tcp udp'
 		else
 			proto='all'
@@ -392,7 +392,7 @@ insert_policy() {
 			param="$param -m multiport $valueNeg --sport ${value//-/:}"
 		fi
 
-		if [ -n "$raddr" ]; then 
+		if [ -n "$raddr" ]; then
 			if [ "${raddr:0:1}" = "!" ]; then
 				valueNeg='!'; value="${raddr:1}"
 			else
@@ -437,7 +437,7 @@ r_process_policy(){
 		return 0
 	fi
 
-	# start non-recursive processing 
+	# start non-recursive processing
 	# process TOR, netmask, physical device and mac-address separately, so we don't send them to resolveip
 	if is_tor "$iface"; then
 		insert_tor_policy "$comment" "$iface" "$laddr" "$lport" "$raddr" "$rport" "$proto" "$chain"
@@ -527,7 +527,7 @@ process_policy(){
 		output_fail; return 1;
 	fi
 
-	lport="${lport//  / }"; lport="${lport// /,}"; lport="${lport//,\!/ !}"; 
+	lport="${lport//  / }"; lport="${lport// /,}"; lport="${lport//,\!/ !}";
 	rport="${rport//  / }"; rport="${rport// /,}"; rport="${rport//,\!/ !}";
 	r_process_policy "$comment" "$iface" "$laddr" "$lport" "$raddr" "$rport" "$proto" "$chain"
 	if [ -n "$processPolicyWarning" ]; then


### PR DESCRIPTION
Sidesteps faulty busybox grep whole word searching

This erroneously permitted dnsmasq-ipset commands to be executed using dnsmasq compiled without ipset support