### PR TITLE
Fix dnsmasq options detection

### DIFF
--- a/vpn-policy-routing/files/vpn-policy-routing.init
+++ b/vpn-policy-routing/files/vpn-policy-routing.init
@@ -196,7 +196,7 @@ is_enabled() {
 			fi
 			;;
 		dnsmasq.ipset)
-			if dnsmasq -v 2>/dev/null | grep -q 'no-ipset' || ! dnsmasq -v 2>/dev/null | grep -q -w 'ipset'; then
+			if dnsmasq -v 2>/dev/null | grep -q 'no-ipset' || ! dnsmasq -v 2>/dev/null | grep -q ' ipset'; then
 				output "$_ERROR_: DNSMASQ ipset support is enabled in $packageName, but DNSMASQ is either not installed or installed DNSMASQ does not support ipsets!\\n"
 				unset remoteIpset
 			fi


### PR DESCRIPTION
Sidesteps faulty busybox grep whole word searching

This erroneously permitted dnsmasq-ipset commands to be executed using dnsmasq compiled without ipset support