### PR TITLE
Fix pull_filter with pull-filter in .ovpn file

### DIFF
--- a/vpn-policy-routing/files/README.md
+++ b/vpn-policy-routing/files/README.md
@@ -827,7 +827,7 @@ Set the following to the appropriate section of your ```.ovpn``` file:
 - For OpenVPN 2.4 and newer client ```.ovpn``` file:
 
     ```text
-    pull_filter 'ignore "redirect-gateway"'
+    pull-filter ignore "redirect-gateway"
     ```
 
 - For OpenVPN 2.3 and older client ```.ovpn``` file:


### PR DESCRIPTION
The correct command for OpenVPN >= 2.7 in .ovpn files seems to be pull-filter and not pull_filter. I also had to remove the '