### PR TITLE
`ip ls` -> `ip list`

### DIFF
--- a/vpn-policy-routing/files/vpn-policy-routing.init
+++ b/vpn-policy-routing/files/vpn-policy-routing.init
@@ -621,7 +621,7 @@ table_create(){
 			ip -4 route add default via "$gw4" dev "$dev" table "$tid" >/dev/null 2>&1 || ipv4_error=1
 #			ip -4 route add default dev "$dev" table "$tid" >/dev/null 2>&1 || ipv4_error=1
 		fi
-		ip -4 route ls table main | grep -v 'br-lan' | while read -r i; do
+		ip -4 route list table main | grep -v 'br-lan' | while read -r i; do
 			idev="$(echo "$i" | grep -Eso 'dev [^ ]*' | awk '{print $2}')"
 			if ! is_supported_iface_dev "$idev"; then
 				ip -4 route add $i table "$tid" >/dev/null 2>&1 || ipv4_error=1
@@ -637,7 +637,7 @@ table_create(){
 			if [ -z "$gw6" ] || [ "$gw6" = "::/0" ]; then
 				ip -6 route add unreachable default table "$tid" || ipv6_error=1
 			else
-				ip -6 route ls table main | grep " dev $dev6 " | while read -r i; do
+				ip -6 route list table main | grep " dev $dev6 " | while read -r i; do
 					ip -6 route add $i table "$tid" >/dev/null 2>&1 || ipv6_error=1
 				done
 			fi


### PR DESCRIPTION
Not sure what the intricacies of this entails but on my router the `ip` command only accepts `ip route list` not `ip route ls`:
```
~# ip
BusyBox v1.31.1 () multi-call binary.

Usage: ip [OPTIONS] address|route|link|neigh|rule [ARGS]

OPTIONS := -f[amily] inet|inet6|link | -o[neline]

ip addr add|del IFADDR dev IFACE | show|flush [dev IFACE] [to PREFIX]
ip route list|flush|add|del|change|append|replace|test ROUTE
ip link set IFACE [up|down] [arp on|off] [multicast on|off]
	[promisc on|off] [mtu NUM] [name NAME] [qlen NUM] [address MAC]
	[master IFACE | nomaster]
ip neigh show|flush [to PREFIX] [dev DEV] [nud STATE]
ip rule [list] | add|del SELECTOR ACTION
```

Gives me this error when I startup without this fix: 
```
Fri Nov  6 19:14:58 2020 daemon.err uhttpd[3312]: ip: invalid argument 'ls' to 'ip'
Fri Nov  6 19:14:58 2020 daemon.err uhttpd[3312]: ip: invalid argument '0x010000/0xff0000' to 'fwmark'
Fri Nov  6 19:14:58 2020 user.notice vpn-policy-routing [6485]: Creating table 'wan/192.168.0.1' [✓]
Fri Nov  6 19:14:58 2020 daemon.err uhttpd[3312]: ip: invalid argument 'ls' to 'ip'
Fri Nov  6 19:14:58 2020 daemon.err uhttpd[3312]: ip: invalid argument '0x020000/0xff0000' to 'fwmark'
Fri Nov  6 19:14:58 2020 user.notice vpn-policy-routing [6485]: Creating table 'wwan//0.0.0.0' [✓]
Fri Nov  6 19:14:58 2020 daemon.err uhttpd[3312]: ip: invalid argument 'ls' to 'ip'
```