### PR TITLE
[luci] luci-app-advanced-reboot: add board config for Linksys EA7500-V1

### DIFF
--- a/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-ea7500v1.json
+++ b/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-ea7500v1.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Linksys",
+	"deviceName": "EA7500v1",
+	"boardNames": [ "linksys,ea7500-v1" ],
+	"partition1MTD": "mtd14",
+	"partition2MTD": "mtd16",
+	"labelOffset": 32,
+	"bootEnv1": "boot_part",
+	"bootEnv1Partition1Value": 1,
+	"bootEnv1Partition2Value": 2,
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
+}


### PR DESCRIPTION
EA7500-v1 works the same as the other Linksys models except
the mtd numbers are 14 and 16.

Signed-off-by: David Adair <djabhead@aol.com>