### PR TITLE
luci-app-advanced-reboot: fix title if dual-partitions are unsupported

### DIFF
--- a/luci-app-advanced-reboot/htdocs/luci-static/resources/view/system/advanced_reboot.js
+++ b/luci-app-advanced-reboot/htdocs/luci-static/resources/view/system/advanced_reboot.js
@@ -197,7 +197,7 @@ return view.extend({
 		if (device_info.error)
 			body.appendChild(E('p', { 'class' : 'alert-message warning'}, _("ERROR: ") + this.translateTable[device_info.error]()));
 
-		body.appendChild(E('h3', device_info.device_name + _(' Partitions')));
+		body.appendChild(E('h3', (device_info.device_name || '') + _(' Partitions')));
 		if (device_info.device_name) {
 			var partitions_table = E('table', { 'class': 'table' }, [
 				E('tr', { 'class': 'tr table-titles' }, [


### PR DESCRIPTION
A tiny fix to remove "undefined" from the title if dual-partitions are not supported:

![screenshot](https://user-images.githubusercontent.com/552590/124277243-1e268780-db45-11eb-82d6-95a2c445db8b.png)
