### PR TITLE
Re issue 147 (softether support)

### DIFF
--- a/vpn-policy-routing/files/vpn-policy-routing.init
+++ b/vpn-policy-routing/files/vpn-policy-routing.init
@@ -131,6 +131,7 @@ is_l2tp() { local proto; proto=$(uci -q get network."$1".proto); [ "${proto:0:4}
 is_oc() { local proto; proto=$(uci -q get network."$1".proto); [ "${proto:0:11}" = "openconnect" ]; }
 is_ovpn() { local dev i; for i in ifname device; do [ -z "$dev" ] && dev="$(uci -q get "network.${1}.${i}")"; done; [ "${dev:0:3}" = "tun" ] || [ "${dev:0:3}" = "tap" ] || [ -f "/sys/devices/virtual/net/${dev}/tun_flags" ]; }
 is_pptp() { local proto; proto=$(uci -q get network."$1".proto); [ "${proto:0:4}" = "pptp" ]; }
+is_softether() { local dev i; for i in ifname device; do [ -z "$dev" ] && dev="$(uci -q get "network.${1}.${i}")"; done; [ "${dev:0:4}" = "vpn_" ] || [ -f "/sys/devices/virtual/net/${dev}/tun_flags" ]; }
 is_tor() { [ "$(str_to_lower "$1")" = "tor" ]; }
 is_tor_running() { 
 	local ret=0
@@ -142,7 +143,7 @@ is_tor_running() {
 	if [ "$ret" = "0" ]; then return 1; else return 0; fi
 }
 is_wg() { local proto; proto=$(uci -q get network."$1".proto); [ "${proto:0:9}" = "wireguard" ]; }
-is_tunnel() { is_l2tp "$1" || is_oc "$1" || is_ovpn "$1" || is_pptp "$1" || is_tor "$1" || is_wg "$1"; }
+is_tunnel() { is_l2tp "$1" || is_oc "$1" || is_ovpn "$1" || is_pptp "$1" || is_softether "$1" || is_tor "$1" || is_wg "$1"; }
 is_wan() { [ "$1" = "$wanIface4" ] || { [ "${1##wan}" != "$1" ] && [ "${1##wan6}" = "$1" ]; } || [ "${1%%wan}" != "$1" ]; }
 is_wan6() { [ -n "$wanIface6" ] && [ "$1" = "$wanIface6" ] || [ "${1/#wan6}" != "$1" ] || [ "${1/%wan6}" != "$1" ]; }
 is_ignored_interface() { str_contains_word "$ignoredIfaces" "$1"; }

--- a/vpn-policy-routing/files/vpn-policy-routing.init
+++ b/vpn-policy-routing/files/vpn-policy-routing.init
@@ -109,6 +109,9 @@ vpr_get_gateway() {
 	local iface="$2" dev="$3" gw
 	network_get_gateway gw "$iface"
 	if [ -z "$gw" ] || [ "$gw" = '0.0.0.0' ]; then
+		network_get_gateway gw "$iface" true
+	fi
+	if [ -z "$gw" ] || [ "$gw" = '0.0.0.0' ]; then
 		gw="$(ip -4 a list dev "$dev" 2>/dev/null | grep inet | awk '{print $2}' | awk -F "/" '{print $1}')"
 	fi
 	eval "$1"='$gw'
@@ -116,6 +119,9 @@ vpr_get_gateway() {
 vpr_get_gateway6() {
 	local iface="$2" dev="$3" gw
 	network_get_gateway6 gw "$iface"
+	if [ -z "$gw" ] || [ "$gw" = '::/0' ] || [ "$gw" = '::0/0' ] || [ "$gw" = '::' ]; then
+		network_get_gateway6 gw "$iface" true
+	fi
 	if [ -z "$gw" ] || [ "$gw" = '::/0' ] || [ "$gw" = '::0/0' ] || [ "$gw" = '::' ]; then
 		gw="$(ip -6 a list dev "$dev" 2>/dev/null | grep inet6 | awk '{print $2}')"
 	fi


### PR DESCRIPTION
Fixes #147 

With the attached edits, vpn-policy-routing (I'm currently running this version on my router) :
* successfully identifies softether-based VPN interfaces (using device-based detection, modeled off the existing is_ovpn code)
* successfully extracts routing gateway info even when default routing is disabled

There is probably a slight risk here that the new gateway extraction logic (look for active default gateway -> *look for inactive default gateway* (the new part) -> fall back onto ip command info) could lead to issues where the correct gateway is currently found in the last step, but now overruled by potentially wrong info from step 2... However, since I don't know for which vpn protocols the ip command-based code actually works, this is difficult to judge.