### PR TITLE
 https-dns-proxy:fix cannot restore empty server value

### DIFF
--- a/https-dns-proxy/files/https-dns-proxy.init
+++ b/https-dns-proxy/files/https-dns-proxy.init
@@ -347,6 +347,8 @@ dnsmasq_restore_server_backup() {
 			uci_add_list_if_new 'dhcp' "$cfg" 'server' "$i"
 		done
 		uci_remove 'dhcp' "$cfg" 'doh_backup_server'
+	else
+		uci_remove 'dhcp' "$cfg" 'server'
 	fi
 }
 


### PR DESCRIPTION
When the value of `dhcp.@dnsmasq[0].server` is empty, the backup value cannot be restored correctly.

Example:
After running the following command, the value of `dhcp.@dnsmasq[0].server` should be empty.
```bash
uci del dhcp.@dnsmasq[0].doh_backup_server
uci del dhcp.@dnsmasq[0].server
uci commit
/etc/init.d/https-dns-proxy start
/etc/init.d/https-dns-proxy stop
```
But actually I will get results like below
```bash
root@OpenWrt:~# uci show dhcp.@dnsmasq[0].server
dhcp.cfg01411c.server='/mask.icloud.com/' '/mask-h2.icloud.com/' '/use-application-dns.net/' '127.0.0.1#5054' '127.0.0.1#5053'
```

This will cause users to stop https-dns-proxy without being able to fall back to normal DNS directly.
This PR fixes the issue.