### PR TITLE
pbr: fixed setup routing fails if any ipv4 route has "linkdown"

### DIFF
--- a/pbr/files/etc/init.d/pbr.init
+++ b/pbr/files/etc/init.d/pbr.init
@@ -1632,6 +1632,8 @@ interface_routing() {
 					fi
 					# shellcheck disable=SC2086
 					while read -r i; do
+						# shellcheck disable=SC2001
+						i="$(echo "$i" | sed 's/linkdown$//')"
 						idev="$(echo "$i" | grep -Eso 'dev [^ ]*' | awk '{print $2}')"
 						if ! is_supported_iface_dev "$idev"; then
 							$ip_full -4 route add $i table "$tid" >/dev/null 2>&1 || ipv4_error=1


### PR DESCRIPTION
I have an interface with no cable configured with "Force link".
![image](https://user-images.githubusercontent.com/5102352/204308217-966de38c-ec8a-421d-a8fc-de7d9fb5cc27.png)

This breaks pbr
/etc/init.d/pbr restart
```
Removing routing for 'wan/eth0/195.16.30.1' [✓]
Removing routing for 'wireguard/192.168.200.1' [✓]
Removing routing for 'pia/tun_pia/10.4.112.239' [✓]
pbr 0.9.9-44 (nft) stopped [✓]
Setting up routing for 'wan/eth0/195.16.30.1' [✗]
Setting up routing for 'wireguard/192.168.200.1' [✗]
Setting up routing for 'pia/tun_pia/10.4.112.239' [✗]
Routing 'iplayer' via wireguard [✓]
Routing 'torrents' via pia [✓]
Routing 'itv' via wireguard [✓]
Restarting dnsmasq [✓]
pbr 0.9.9-44 monitoring interfaces: wan wireguard pia 
ERROR: Failed to set up 'wan/eth0/195.16.30.1'!
ERROR: Failed to set up 'wireguard/192.168.200.1'!
ERROR: Failed to set up 'pia/tun_pia/10.4.112.239'!
ERROR: Failed to set up any gateway!
```

this patch removes "linkdown" from the route when adding it to the new table