### PR TITLE
luci-app-advanced-reboot: (Create xiaomi-ax3600.json)

### DIFF
--- a/luci-app-advanced-reboot/Makefile
+++ b/luci-app-advanced-reboot/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.0.1-5
+PKG_VERSION:=1.0.1-6
 
 LUCI_TITLE:=Advanced OpenWRT Reboot Web UI
 LUCI_URL:=https://docs.openwrt.melmac.net/luci-app-advanced-reboot/

--- a/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/xiaomi-ax3600.json
+++ b/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/xiaomi-ax3600.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Xiaomi",
+	"deviceName": "AX3600",
+	"boardNames": [ "xiaomi,ax3600" ],
+	"partition1MTD": "mtd12",
+	"partition2MTD": "mtd13",
+	"labelOffset": 266432,
+	"bootEnv1": "flag_boot_rootfs",
+	"bootEnv1Partition1Value": 0,
+	"bootEnv1Partition2Value": 1,
+	"bootEnv2": "flag_last_success",
+	"bootEnv2Partition1Value": 0,
+	"bootEnv2Partition2Value": 1
+}


### PR DESCRIPTION
This was tested on the robimarko's firmware OpenWrt SNAPSHOT r21392.

```
root@AX3600:~# cat /proc/mtd
dev:    size   erasesize  name
mtd0: 00100000 00020000 "0:sbl1"
mtd1: 00100000 00020000 "0:mibib"
mtd2: 00300000 00020000 "0:qsee"
mtd3: 00080000 00020000 "0:devcfg"
mtd4: 00080000 00020000 "0:rpm"
mtd5: 00080000 00020000 "0:cdt"
mtd6: 00080000 00020000 "0:appsblenv"
mtd7: 00100000 00020000 "0:appsbl"
mtd8: 00080000 00020000 "0:art"
mtd9: 00080000 00020000 "bdata"
mtd10: 00080000 00020000 "crash"
mtd11: 00080000 00020000 "crash_syslog"
mtd12: 023c0000 00020000 "rootfs"
mtd13: 023c0000 00020000 "rootfs_1"
mtd14: 01ec0000 00020000 "overlay"
mtd15: 00080000 00020000 "rsvd0"
```
