### PR TITLE
luci-app-advanced-reboot: add Redmi AX6 support

### DIFF
--- a/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/redmi-ax6.json
+++ b/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/redmi-ax6.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Redmi",
+	"deviceName": "AX6",
+	"boardNames": [ "redmi,ax6" ],
+	"partition1MTD": "mtd12",
+	"partition2MTD": "mtd13",
+	"labelOffset": 266432,
+	"bootEnv1": "flag_boot_rootfs",
+	"bootEnv1Partition1Value": 0,
+	"bootEnv1Partition2Value": 1,
+	"bootEnv2": "flag_last_success",
+	"bootEnv2Partition1Value": 0,
+	"bootEnv2Partition2Value": 1
+}


### PR DESCRIPTION
The Redmi AX6 is almost identical to the recently supported Xiaomi AX3600.

These devices are not supported by OpenWRT upstream yet but there will be a PR for official support soon.