### PR TITLE
Proposal: matching provider domain for providers which offer custom profiles

### DIFF
--- a/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.family.lua
+++ b/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.family.lua
@@ -2,6 +2,7 @@ return {
 	name = "freedns.controld.com-family",
 	label = _("ControlD (Family)"),
 	resolver_url = "https://freedns.controld.com/family",
+	provider_domain = "controld.com",
 	bootstrap_dns = "76.76.2.4,2606:1a40::4",
 	help_link = "https://kb.controld.com/tutorials",
 	help_link_text = "ControlD.com"

--- a/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p0.lua
+++ b/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p0.lua
@@ -2,6 +2,7 @@ return {
 	name = "freedns.controld.com-p0",
 	label = _("ControlD (Unfiltered)"),
 	resolver_url = "https://freedns.controld.com/p0",
+	provider_domain = "controld.com",
 	bootstrap_dns = "76.76.2.0,2606:1a40::0",
 	help_link = "https://kb.controld.com/tutorials",
 	help_link_text = "ControlD.com"

--- a/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p1.lua
+++ b/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p1.lua
@@ -2,6 +2,7 @@ return {
 	name = "freedns.controld.com-p1",
 	label = _("ControlD (Block Malware)"),
 	resolver_url = "https://freedns.controld.com/p1",
+	provider_domain = "controld.com",
 	bootstrap_dns = "76.76.2.1,2606:1a40::1",
 	help_link = "https://kb.controld.com/tutorials",
 	help_link_text = "ControlD.com"

--- a/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p2.lua
+++ b/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p2.lua
@@ -2,6 +2,7 @@ return {
 	name = "freedns.controld.com-p2",
 	label = _("ControlD (Block Malware + Ads)"),
 	resolver_url = "https://freedns.controld.com/p2",
+	provider_domain = "controld.com",
 	bootstrap_dns = "76.76.2.2,2606:1a40::2",
 	help_link = "https://kb.controld.com/tutorials",
 	help_link_text = "ControlD.com"

--- a/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p3.lua
+++ b/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p3.lua
@@ -2,6 +2,7 @@ return {
 	name = "freedns.controld.com-p3",
 	label = _("ControlD (Block Malware + Ads + Social)"),
 	resolver_url = "https://freedns.controld.com/p3",
+	provider_domain = "controld.com",
 	bootstrap_dns = "76.76.2.3,2606:1a40::3",
 	help_link = "https://kb.controld.com/tutorials",
 	help_link_text = "ControlD.com"

--- a/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/google.dns.lua
+++ b/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/google.dns.lua
@@ -2,5 +2,6 @@ return {
 	name = "dns.google",
 	label = _("Google"),
 	resolver_url = "https://dns.google/dns-query",
+	provider_domain = "https.dns.proxy"
 	bootstrap_dns = "8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844"
 }

--- a/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.nextdns.dns.lua
+++ b/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.nextdns.dns.lua
@@ -2,6 +2,7 @@ return {
 	name = "dns.nextdns.io",
 	label = _("NextDNS.io (Configurable)"),
 	resolver_url = "https://dns.nextdns.io/",
+	provider_domain = "nextdns.io",
 	bootstrap_dns = "45.90.28.49,45.90.30.49",
 	help_link = " https://my.nextdns.io",
 	help_link_text = "NextDNS.io"

--- a/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -58,7 +58,8 @@ function getProviderName(value)
 		local p = p_func()
 		value = value:gsub('[%p%c%s]', '')
 		p.url_match = p.resolver_url:gsub('[%p%c%s]', '')
-		if value:match(p.url_match) then
+		p.provider_match = p.provider_domain:gsub('[%p%c%s]', '')
+		if (value:match(p.url_match)) or (value:find(p.provider_match)) then
 			return p.label
 		end
 	end


### PR DESCRIPTION
@stangri apologies; not sure of the etiquette or decorum around proposals such as this.

Some DNS providers (e.g. ControlD and NextDNS) allow the creation of custom profiles. In such cases, unique DoH URLs are generated. E.g. a ControlD resolver looks like `https://dns.controld.com/<profileid>`

In such cases, 'Unknown Provider' is shown since the URL in the https-dns-proxy config does not match a `resolver_url` in the list of providers. 

Therefore, I would like to propose that provider domains are also used to identify the DoH provider, rather than just the full `resolver_url`. Where custom profiles aren't available, I've simply set the value of `provider_domain` to "https.dns.proxy"

If this approach in this PR is useful, then I would be happy to continue along this path.