### PR TITLE
Makefiles: Use absolute path for luci.mk

### DIFF
--- a/luci-app-adblock-fast/Makefile
+++ b/luci-app-adblock-fast/Makefile
@@ -12,6 +12,6 @@ LUCI_DESCRIPTION:=Provides Web UI for adblock-fast service.
 LUCI_DEPENDS:=+luci-base +adblock-fast +jsonfilter
 LUCI_PKGARCH:=all
 
-include ../../luci.mk
+include $(TOPDIR)/feeds/luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/luci-app-advanced-reboot/Makefile
+++ b/luci-app-advanced-reboot/Makefile
@@ -15,6 +15,6 @@ LUCI_DESCRIPTION:=Provides Web UI (found under System/Advanced Reboot) to reboot
 LUCI_DEPENDS:=+luci-mod-admin-full +jshn
 LUCI_PKGARCH:=all
 
-include ../../luci.mk
+include $(TOPDIR)/feeds/luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/luci-app-fakeinternet/Makefile
+++ b/luci-app-fakeinternet/Makefile
@@ -12,6 +12,6 @@ LUCI_DESCRIPTION:=Provides Web UI for Fakeinternet.
 LUCI_DEPENDS:=+luci-compat +luci-base +fakeinternet
 LUCI_PKGARCH:=all
 
-include ../../luci.mk
+include $(TOPDIR)/feeds/luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/luci-app-https-dns-proxy/Makefile
+++ b/luci-app-https-dns-proxy/Makefile
@@ -12,6 +12,6 @@ LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy
 LUCI_DEPENDS:=+luci-base +https-dns-proxy
 LUCI_PKGARCH:=all
 
-include ../../luci.mk
+include $(TOPDIR)/feeds/luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/luci-app-pbr/Makefile
+++ b/luci-app-pbr/Makefile
@@ -14,6 +14,6 @@ LUCI_PKGARCH:=all
 
 PKG_PROVIDES:=luci-app-vpnbypass luci-app-vpn-policy-routing
 
-include ../../luci.mk
+include $(TOPDIR)/feeds/luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/luci-app-wireshark-helper/Makefile
+++ b/luci-app-wireshark-helper/Makefile
@@ -12,6 +12,6 @@ LUCI_DESCRIPTION:=Provides Web UI for Wireshark-helper.
 LUCI_DEPENDS:=+luci-compat +luci-base +wireshark-helper
 LUCI_PKGARCH:=all
 
-include ../../luci.mk
+include $(TOPDIR)/feeds/luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/luci-app-wlanblinker/Makefile
+++ b/luci-app-wlanblinker/Makefile
@@ -12,6 +12,6 @@ LUCI_DESCRIPTION:=Provides Web UI for WLAN Blinker service.
 LUCI_DEPENDS:=+luci-compat +luci-base +wlanblinker
 LUCI_PKGARCH:=all
 
-include ../../luci.mk
+include $(TOPDIR)/feeds/luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/luci-proto-nebula/Makefile
+++ b/luci-proto-nebula/Makefile
@@ -12,6 +12,6 @@ LUCI_DESCRIPTION:=Provides Web UI for Nebula protocol/interface.
 LUCI_DEPENDS:=+nebula +nebula-proto
 LUCI_PKGARCH:=all
 
-include ../../luci.mk
+include $(TOPDIR)/feeds/luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature


### PR DESCRIPTION
Relative path will cause issues for custom repositories.