### PR TITLE
pbr: skip disabled interfaces in pbr.user.wg_server_and_client

### DIFF
--- a/pbr/Makefile
+++ b/pbr/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.1.5
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 

--- a/pbr/files/usr/share/pbr/pbr.user.wg_server_and_client
+++ b/pbr/files/usr/share/pbr/pbr.user.wg_server_and_client
@@ -6,10 +6,11 @@ WAN_INTERFACE='wan'
 _ret='1'
 
 insert_ip_rule() {
-	local proto listen_port
+	local disabled proto listen_port
+	config_get disabled "$1" disabled "0"
 	config_get proto "$1" proto
 	config_get listen_port "$1" listen_port
-	if [ "$proto" = 'wireguard' ] && [ -n "$listen_port" ]; then
+	if [ "$disabled" -ne '1' ] && [ "$proto" = 'wireguard' ] && [ -n "$listen_port" ]; then
 		ip rule del sport "$listen_port" table "pbr_${WAN_INTERFACE}" >/dev/null 2>&1
 		ip rule add sport "$listen_port" table "pbr_${WAN_INTERFACE}" >/dev/null 2>&1 && _ret=0
 	fi


### PR DESCRIPTION
Maintainer: Stan Grishin <stangri@melmac.ca>
Compile tested: aarch64, cortex-a53, OpenWRT Main, PBR 1.1.5.5
Run tested: Dynalink DL-WRX36

Description:
The pbr.user.wg_server_and_client script is very useful and works well, a great addition. But on my test router I have a lot of (wireguard) interfaces with a listen port. When testing most are disabled but these disabled interfaces are still processed, not a big problem but I propose to test for disabled. This patch add the test if an interface is disabled. If you think it is useful, does not break things and up to your standards please implement otherwise just discard

Signed-off-by: Erik Conijn egc112@msn.com