### PR TITLE
pbr: missing nft set in pbr.usr.aws

### DIFF
--- a/pbr/Makefile
+++ b/pbr/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.1.5
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 

--- a/pbr/files/usr/share/pbr/pbr.user.aws
+++ b/pbr/files/usr/share/pbr/pbr.user.aws
@@ -17,7 +17,7 @@ if [ ! -s "$TARGET_DL_FILE_4" ]; then
 	uclient-fetch --no-check-certificate -qO- "$TARGET_URL" 2>/dev/null | grep "ip_prefix" | sed 's/^.*\"ip_prefix\": \"//; s/\",//' > "$TARGET_DL_FILE_4"
 fi
 if [ -s "$TARGET_DL_FILE_4" ]; then
-	if [ -n "$nft" ] && [ -x "$nft" ]; then
+	if [ -n "$nft" ] && [ -x "$nft" ] && "$nft" list set "$TARGET_TABLE" $TARGET_NFTSET_4 >/dev/null 2>&1; then
 		while read -r p; do "$nft" "add element $TARGET_TABLE $TARGET_NFTSET_4 { $p }" || _ret=1; done < "$TARGET_DL_FILE_4"
 	elif ipset -q list "$TARGET_IPSET_4" >/dev/null 2>&1; then
 		if awk -v ipset="$TARGET_IPSET_4" '{print "add " ipset " " $1}' "$TARGET_DL_FILE_4" | ipset restore -!; then
@@ -32,7 +32,7 @@ if [ -n "$TARGET_DL_FILE_6" ] && [ ! -s "$TARGET_DL_FILE_6" ]; then
 	uclient-fetch --no-check-certificate -qO- "$TARGET_URL" 2>/dev/null | grep "ipv6_prefix" | sed 's/^.*\"ipv6_prefix\": \"//; s/\",//' > "$TARGET_DL_FILE_6"
 fi
 if [ -s "$TARGET_DL_FILE_6" ]; then
-	if [ -n "$nft" ] && [ -x "$nft" ]; then
+	if [ -n "$nft" ] && [ -x "$nft" ] && "$nft" list set "$TARGET_TABLE" $TARGET_NFTSET_6 >/dev/null 2>&1; then
 		while read -r p; do "$nft" "add element $TARGET_TABLE $TARGET_NFTSET_6 { $p }" || _ret=1; done < "$TARGET_DL_FILE_6"
 	elif ipset -q list "$TARGET_IPSET_6" >/dev/null 2>&1; then
 		if awk -v ipset="$TARGET_IPSET_6" '{print "add " ipset " " $1}' "$TARGET_DL_FILE_6" | ipset restore -!; then


### PR DESCRIPTION
Maintainer: Stan Grishin <stangri@melmac.ca>
Compile tested: aarch64, cortex-a53, OpenWRT Main
Run tested: Dynalink DL-WRX36

Description:
See: https://forum.openwrt.org/t/policy-based-routing-pbr-package-discussion/140639/986 User has trouble with using include file ` pbr.usr.aws` I tested it with pbr 1.1.5.6 and can confirm the problem. Debugging the script shows that the script correctly gets the IP addresses but when trying to add the ip addresses to nft set
 (`while read -r p; do "$nft" "add element $TARGET_TABLE $TARGET_NFTSET_4 { $p }" || _ret=1; done < "$TARGET_DL_FILE_4"`)

Error: No such file or directory
add element inet fw4 pbr_wan_4_dst_ip_user

When looking into fw4 that specific nft set is indeed missing

When comparing with earlier pbr 1.1.4, I noticed that an nft set is first made. I have added the making of the nft set both for IPv4 and IPv6 in the script. I have tested it with IPv4 and this seems to solve the problem.

I am not 100% sure this is the correct solution but it seems to work

Please have a look

Thanks for this excellent and very useful package

Signed-off-by: Erik Conijn egc112@msn.com